### PR TITLE
Feauting -> Featuring typo fix in speaker-logo-scroll.html

### DIFF
--- a/_includes/speaker-logo-scroll.html
+++ b/_includes/speaker-logo-scroll.html
@@ -1,6 +1,6 @@
 <div class="speaker-logos-scroll">
     <div class="py-2 bg-black text-white font-bold justify-center flex">
-        <p>Featuing Speakers From</p>
+        <p>Featuring Speakers From</p>
     </div>
     <div class="scroll-content">
         {% for logo in site.logos %}


### PR DESCRIPTION
I normally don’t bother with typo fixes, but this is on the landing page, so people will notice. (I did a double take and had my coffee which gave me the urge to fix it :))